### PR TITLE
UPDATE system-tests connectors path

### DIFF
--- a/google-datacatalog-hive-connector/Dockerfile
+++ b/google-datacatalog-hive-connector/Dockerfile
@@ -22,8 +22,8 @@ RUN flake8 src tests
 
 RUN python setup.py test
 
-# Install hive2datacatalog package from source files.
+# Install google-datacatalog-hive-connector package from source files.
 RUN pip install .
 
-ENTRYPOINT ["hive2datacatalog"]
+ENTRYPOINT ["google-datacatalog-hive-connector"]
 

--- a/google-datacatalog-hive-connector/cloudbuild.connector.yaml
+++ b/google-datacatalog-hive-connector/cloudbuild.connector.yaml
@@ -14,6 +14,12 @@
 # limitations under the License.
 
 steps:
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'BUILD'
+  args: ['build',
+         '-t',
+         'gcr.io/$PROJECT_ID/hive2datacatalog:$COMMIT_SHA',
+         '/workspace/google-datacatalog-hive-connector/.']
 - name: 'gcr.io/cloudshell-images/cloudshell:latest'
   id: 'GET_PACKAGE'
   entrypoint: '/bin/bash'
@@ -25,8 +31,21 @@ steps:
   args: ['-c',
          'tar -zxvf /workspace/hive-0.0.2.tar.gz']
 - name: 'gcr.io/cloudshell-images/cloudshell:latest'
-  id: 'CREATE_ENV'
+  id: 'PREPARE_SERVICE_ACCOUNT'
+  args: ['cp',
+         'gs://connectors_build_env/hive2dc-datacatalog-credentials.json',
+         '/workspace/hive/hive2dc-credentials.json']         
+- name: 'gcr.io/cloudshell-images/cloudshell:latest'
+  id: 'PREPARE_ENV'
   entrypoint: '/bin/bash'
+  args: ['-c',
+         'cd /workspace/hive && ./cleanup-datacatalog.sh']            
+- name: 'gcr.io/cloudshell-images/cloudshell:latest'
+  id: 'RUN'
+  entrypoint: '/bin/bash'
+  env:
+  - 'PROJECT_ID=${PROJECT_ID}'
+  - 'CONNECTOR_TAG_NAME=${COMMIT_SHA}'
   args: ['-c',
          'cd /workspace/hive && ./run-demo.sh']
 - name: 'gcr.io/cloudshell-images/cloudshell:latest'

--- a/google-datacatalog-hive-connector/cloudbuild.connector.yaml
+++ b/google-datacatalog-hive-connector/cloudbuild.connector.yaml
@@ -30,7 +30,7 @@ steps:
   entrypoint: '/bin/bash'
   args: ['-c',
          'tar -zxvf /workspace/hive-0.0.2.tar.gz']
-- name: 'gcr.io/cloudshell-images/cloudshell:latest'
+- name: 'gcr.io/cloud-builders/gsutil'
   id: 'PREPARE_SERVICE_ACCOUNT'
   args: ['cp',
          'gs://connectors_build_env/hive2dc-credentials.json',

--- a/google-datacatalog-hive-connector/cloudbuild.connector.yaml
+++ b/google-datacatalog-hive-connector/cloudbuild.connector.yaml
@@ -20,6 +20,13 @@ steps:
          '-t',
          'gcr.io/$PROJECT_ID/hive2datacatalog:$COMMIT_SHA',
          '/workspace/google-datacatalog-hive-connector/.']
+- name: 'alpine'
+  id: 'SETUP_TAG'
+  args: ['sh',
+         '-c',
+         "echo `echo $BRANCH_NAME |
+          sed 's,/,-,g' |
+          awk '{print tolower($0)}'`_$(date -u +%Y%m%dT%H%M)_$SHORT_SHA > _TAG; echo $(cat _TAG)"]         
 - name: 'gcr.io/cloudshell-images/cloudshell:latest'
   id: 'GET_PACKAGE'
   entrypoint: '/bin/bash'
@@ -48,9 +55,16 @@ steps:
   - 'CONNECTOR_TAG_NAME=${COMMIT_SHA}'
   args: ['-c',
          'cd /workspace/hive && ./run-demo.sh']
+  # Tag image with the custom tag
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'TAG_IMAGE'
+  entrypoint: '/bin/bash'
+  args: ['-c',
+         "docker tag gcr.io/$PROJECT_ID/hive2datacatalog:$COMMIT_SHA gcr.io/$PROJECT_ID/hive2datacatalog:$(cat _TAG)"]         
 - name: 'gcr.io/cloudshell-images/cloudshell:latest'
   id: 'DELETE_ENV'
   entrypoint: '/bin/bash'
   args: ['-c',
-         'cd /workspace/hive && ./delete-demo.sh']         
+         'cd /workspace/hive && ./delete-demo.sh']   
+images: ['gcr.io/$PROJECT_ID/hive2datacatalog']
 timeout: 30m

--- a/google-datacatalog-hive-connector/cloudbuild.connector.yaml
+++ b/google-datacatalog-hive-connector/cloudbuild.connector.yaml
@@ -33,8 +33,8 @@ steps:
 - name: 'gcr.io/cloudshell-images/cloudshell:latest'
   id: 'PREPARE_SERVICE_ACCOUNT'
   args: ['cp',
-         'gs://connectors_build_env/hive2dc-datacatalog-credentials.json',
-         '/workspace/hive/hive2dc-credentials.json']         
+         'gs://connectors_build_env/hive2dc-credentials.json',
+         '/workspace/hive/.']         
 - name: 'gcr.io/cloudshell-images/cloudshell:latest'
   id: 'PREPARE_ENV'
   entrypoint: '/bin/bash'

--- a/google-datacatalog-hive-connector/cloudbuild.connector.yaml
+++ b/google-datacatalog-hive-connector/cloudbuild.connector.yaml
@@ -14,32 +14,18 @@
 # limitations under the License.
 
 steps:
-# This step runs builds the docker container which runs flake8, yapf and unit tests
-- name: 'gcr.io/cloud-builders/docker'
-  id: 'BUILD'
-  args: ['build',
-         '-t',
-         'gcr.io/$PROJECT_ID/hive2datacatalog:$COMMIT_SHA',
-         '.']
+- name: 'gcr.io/cloudshell-images/cloudshell:latest'
+  id: 'GET_PACKAGE'
+  entrypoint: '/bin/bash'
+  args: ['-c',
+         'gsutil cp gs://datacatalog-connector-tools/hive-0.0.1.tar.gz .']
   # Create custom image tag and write to file /workspace/_TAG
-- name: 'alpine'
-  id: 'SETUP_TAG'
-  args: ['sh',
-         '-c',
-         "echo `echo $BRANCH_NAME |
-          sed 's,/,-,g' |
-          awk '{print tolower($0)}'`_$(date -u +%Y%m%dT%H%M)_$SHORT_SHA > _TAG; echo $(cat _TAG)"]
-  # Tag image with custom tag
-- name: 'gcr.io/cloud-builders/docker'
-  id: 'TAG_IMAGE'
-  entrypoint: '/bin/bash'
+- name: 'gcr.io/cloudshell-images/cloudshell:latest'
+  id: 'UNTAR'
   args: ['-c',
-         "docker tag gcr.io/$PROJECT_ID/hive2datacatalog:$COMMIT_SHA gcr.io/$PROJECT_ID/hive2datacatalog:$(cat _TAG)"]
- # ADD Validation step before tagging stable
-- name: 'gcr.io/cloud-builders/docker'
-  id: 'TAG_STABLE'
-  entrypoint: '/bin/bash'
+         'tar -zxvf /workspace/hive-0.0.1.tar.gz']
+- name: 'gcr.io/cloudshell-images/cloudshell:latest'
+  id: 'RUN'
   args: ['-c',
-         "docker tag gcr.io/$PROJECT_ID/hive2datacatalog:$COMMIT_SHA gcr.io/$PROJECT_ID/hive2datacatalog:stable"]
-images: ['gcr.io/$PROJECT_ID/hive2datacatalog']
+         '/workspace/hive/run-demo.sh']
 timeout: 15m

--- a/google-datacatalog-hive-connector/cloudbuild.connector.yaml
+++ b/google-datacatalog-hive-connector/cloudbuild.connector.yaml
@@ -18,15 +18,20 @@ steps:
   id: 'GET_PACKAGE'
   entrypoint: '/bin/bash'
   args: ['-c',
-         'gsutil cp gs://datacatalog-connector-tools/hive-0.0.1.tar.gz .']
+         'gsutil cp gs://datacatalog-connector-tools/hive-0.0.2.tar.gz .']
 - name: 'gcr.io/cloudshell-images/cloudshell:latest'
   id: 'EXTRACT'
   entrypoint: '/bin/bash'
   args: ['-c',
-         'tar -zxvf /workspace/hive-0.0.1.tar.gz']
+         'tar -zxvf /workspace/hive-0.0.2.tar.gz']
 - name: 'gcr.io/cloudshell-images/cloudshell:latest'
   id: 'CREATE_ENV'
   entrypoint: '/bin/bash'
   args: ['-c',
          'cd /workspace/hive && ./run-demo.sh']
+- name: 'gcr.io/cloudshell-images/cloudshell:latest'
+  id: 'DELETE_ENV'
+  entrypoint: '/bin/bash'
+  args: ['-c',
+         'cd /workspace/hive && ./delete-demo.sh']         
 timeout: 30m

--- a/google-datacatalog-hive-connector/cloudbuild.connector.yaml
+++ b/google-datacatalog-hive-connector/cloudbuild.connector.yaml
@@ -19,13 +19,14 @@ steps:
   entrypoint: '/bin/bash'
   args: ['-c',
          'gsutil cp gs://datacatalog-connector-tools/hive-0.0.1.tar.gz .']
-  # Create custom image tag and write to file /workspace/_TAG
 - name: 'gcr.io/cloudshell-images/cloudshell:latest'
-  id: 'UNTAR'
+  id: 'EXTRACT'
+  entrypoint: '/bin/bash'
   args: ['-c',
          'tar -zxvf /workspace/hive-0.0.1.tar.gz']
 - name: 'gcr.io/cloudshell-images/cloudshell:latest'
-  id: 'RUN'
+  id: 'CREATE_ENV'
+  entrypoint: '/bin/bash'
   args: ['-c',
          '/workspace/hive/run-demo.sh']
-timeout: 15m
+timeout: 30m

--- a/google-datacatalog-hive-connector/cloudbuild.connector.yaml
+++ b/google-datacatalog-hive-connector/cloudbuild.connector.yaml
@@ -28,5 +28,5 @@ steps:
   id: 'CREATE_ENV'
   entrypoint: '/bin/bash'
   args: ['-c',
-         'cd /workspace/hive && run-demo.sh']
+         'cd /workspace/hive && ./run-demo.sh']
 timeout: 30m

--- a/google-datacatalog-hive-connector/cloudbuild.connector.yaml
+++ b/google-datacatalog-hive-connector/cloudbuild.connector.yaml
@@ -28,5 +28,5 @@ steps:
   id: 'CREATE_ENV'
   entrypoint: '/bin/bash'
   args: ['-c',
-         '/workspace/hive/run-demo.sh']
+         'cd /workspace/hive && run-demo.sh']
 timeout: 30m

--- a/google-datacatalog-hive-connector/cloudbuild.connector.yaml
+++ b/google-datacatalog-hive-connector/cloudbuild.connector.yaml
@@ -34,7 +34,7 @@ steps:
   id: 'PREPARE_SERVICE_ACCOUNT'
   args: ['cp',
          'gs://connectors_build_env/hive2dc-credentials.json',
-         '/workspace/hive/.']         
+         '/workspace/hive/infrastructure/.']         
 - name: 'gcr.io/cloudshell-images/cloudshell:latest'
   id: 'PREPARE_ENV'
   entrypoint: '/bin/bash'

--- a/google-datacatalog-hive-connector/cloudbuild.connector.yaml
+++ b/google-datacatalog-hive-connector/cloudbuild.connector.yaml
@@ -56,6 +56,16 @@ steps:
   args: ['-c',
          'cd /workspace/hive && ./run-demo.sh']
   # Tag image with the custom tag
+- name: 'docker.io/library/python:3.7'
+  id: 'ASSERT_RESULTS'
+  entrypoint: 'bash'
+  env:
+  - 'GOOGLE_APPLICATION_CREDENTIALS=/workspace/hive/infrastructure/hive2dc-credentials.json'
+  - 'HIVE2DC_DATACATALOG_PROJECT_ID=${PROJECT_ID}'
+  args:
+  - -c
+  - 'pip install google-cloud-datacatalog &&
+     /workspace/google-datacatalog-hive-connector/system_tests/assert.sh'  
 - name: 'gcr.io/cloud-builders/docker'
   id: 'TAG_IMAGE'
   entrypoint: '/bin/bash'

--- a/google-datacatalog-hive-connector/system_tests/assert.sh
+++ b/google-datacatalog-hive-connector/system_tests/assert.sh
@@ -17,4 +17,4 @@
 # Sleep 5 seconds to wait for search index
 sleep 5
 echo 'Assert INGESTION'
-python system_tests/execution_results_test.py
+python google-datacatalog-hive-connector/system_tests/execution_results_test.py

--- a/google-datacatalog-hive-connector/system_tests/assert.sh
+++ b/google-datacatalog-hive-connector/system_tests/assert.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -eu
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sleep 5 seconds to wait for search index
+sleep 5
+echo 'Assert INGESTION'
+python system_tests/execution_results_test.py

--- a/google-datacatalog-hive-connector/system_tests/execution_results_test.py
+++ b/google-datacatalog-hive-connector/system_tests/execution_results_test.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from google.cloud import datacatalog
+from google.cloud.datacatalog import types
+
+datacatalog = datacatalog.DataCatalogClient()
+
+
+class ExecutionResultsTest(unittest.TestCase):
+
+    def test_tableau_entries_should_exist_after_connector_execution(self):
+        query = 'system=hive'
+
+        scope = types.SearchCatalogRequest.Scope()
+        scope.include_project_ids.append(
+            os.environ['HIVE2DC_DATACATALOG_PROJECT_ID'])
+
+        search_results = [
+            result for result in datacatalog.search_catalog(
+                scope=scope, query=query, order_by='relevance', page_size=1000)
+        ]
+        self.assertGreater(len(search_results), 0)


### PR DESCRIPTION
- What I did
Updated the system-tests directories path. Since we changed to a mono-repo, the system tests were disabled. Updating the new path so we can enable them.

- How I did it
Each connector uses its local directory to run system tests.

- How to verify it
Trigger system-tests.

- Description for the changelog

UPDATE system-tests connectors path.