### PR TITLE
UPDATE event poll constant name

### DIFF
--- a/google-datacatalog-apache-atlas-connector/src/google/datacatalog_connectors/apache_atlas/sync/metadata_event_synchronizer.py
+++ b/google-datacatalog-apache-atlas-connector/src/google/datacatalog_connectors/apache_atlas/sync/metadata_event_synchronizer.py
@@ -28,7 +28,7 @@ from google.datacatalog_connectors.apache_atlas.sync import \
 
 
 class MetadataEventSynchronizer(metadata_synchronizer.MetadataSynchronizer):
-    __EVENT_POLL_SLEEP_TIME_MS = 5
+    __EVENT_POLL_SLEEP_TIME_SECONDS = 5
     __STRING_TYPE = enums.FieldType.PrimitiveType.STRING
 
     def __init__(self,
@@ -53,7 +53,7 @@ class MetadataEventSynchronizer(metadata_synchronizer.MetadataSynchronizer):
         while True:
             self.__run()
             logging.info('===> Sleeping...')
-            sleep(self.__EVENT_POLL_SLEEP_TIME_MS)
+            sleep(self.__EVENT_POLL_SLEEP_TIME_SECONDS)
 
     def __run(self):
         """Coordinates a full scrape > prepare > ingest process."""


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-hive/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Changed the `__EVENT_POLL_SLEEP_TIME_MS` constant to `__EVENT_POLL_SLEEP_TIME_SECONDS `
The name was incorrect, and since the used sleep function expect seconds.

**- How I did it**
Renamed it.

**- How to verify it**
Self explanatory.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Changed the `__EVENT_POLL_SLEEP_TIME_MS` constant to `__EVENT_POLL_SLEEP_TIME_SECONDS `
