### PR TITLE
Set fixed versions before datacatalog v2 client breaking change

### DIFF
--- a/google-datacatalog-apache-atlas-connector/setup.py
+++ b/google-datacatalog-apache-atlas-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-apache-atlas-connector',
-    version='0.5.1',
+    version='0.5.2',
     author='Google LLC',
     description='Package for ingesting Apache Atlas metadata'
     ' into Google Cloud Data Catalog',
@@ -40,10 +40,10 @@ setuptools.setup(
     install_requires=(
         'atlasclient',
         'kafka-python',
-        'google-datacatalog-connectors-commons'
+        'google-datacatalog-connectors-commons>=0.5.2,<0.6.0'
     ),
     setup_requires=('pytest-runner',),
-    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test'),
+    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test>=0.5.1,<0.6.0'),
     classifiers=(
         release_status,
         'Programming Language :: Python :: 3.7',

--- a/google-datacatalog-hive-connector/setup.py
+++ b/google-datacatalog-hive-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-hive-connector',
-    version='0.6.0',
+    version='0.6.1',
     author='Google LLC',
     description=
     'Library for ingesting Hive metadata into Google Cloud Data Catalog',
@@ -41,10 +41,10 @@ setuptools.setup(
         'psycopg2-binary',
         'mysqlclient',
         'sqlalchemy',
-        'google-datacatalog-connectors-commons',
+        'google-datacatalog-connectors-commons>=0.5.2,<0.6.0',
     ),
     setup_requires=('pytest-runner',),
-    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test'),
+    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test>=0.5.1,<0.6.0'),
     classifiers=(
         release_status,
         'Programming Language :: Python :: 3.7',

--- a/tools/create-current-version-tags.sh
+++ b/tools/create-current-version-tags.sh
@@ -32,7 +32,7 @@ create-current-version-tags::main(){
         if [[ $? -eq 0 ]]
             then
                 echo " tag: ${tag_name} created"
-                git_remote_url="$(git remote get-url origin).git"
+                git_remote_url="$(git remote get-url origin)"
                 git_auth_remote_url="${git_remote_url/github.com/${GITHUB_TOKEN}@github.com}"
                 git push ${git_auth_remote_url} ${tag_name}
                 echo " tag: ${tag_name} pushed!"


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-rdbms/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Set fixed versions before datacatalog v2 client breaking change

**- How I did it**
Fixed dependencies versions on `setup.py`, so it's going to use versions before v2 client breaking change.

**- How to verify it**
Install rdbms connectors from PyPI

**- Description for the changelog**
Set fixed versions before datacatalog v2 client breaking change

