### PR TITLE
Upgrade datacatalog client library version to 2.0.0

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         build-dir: ['./google-datacatalog-hive-connector', './google-datacatalog-apache-atlas-connector']
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
     defaults:
       run:
         working-directory: ${{ matrix.build-dir }}

--- a/google-datacatalog-apache-atlas-connector/setup.py
+++ b/google-datacatalog-apache-atlas-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-apache-atlas-connector',
-    version='0.5.2',
+    version='0.6.0',
     author='Google LLC',
     description='Package for ingesting Apache Atlas metadata'
     ' into Google Cloud Data Catalog',
@@ -40,10 +40,10 @@ setuptools.setup(
     install_requires=(
         'atlasclient',
         'kafka-python',
-        'google-datacatalog-connectors-commons>=0.5.2,<0.6.0'
+        'google-datacatalog-connectors-commons>=0.6.0'
     ),
     setup_requires=('pytest-runner',),
-    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test>=0.5.1,<0.6.0'),
+    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test>=0.6.0'),
     classifiers=(
         release_status,
         'Programming Language :: Python :: 3.7',

--- a/google-datacatalog-apache-atlas-connector/src/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-apache-atlas-connector/src/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_entry_factory.py
@@ -148,8 +148,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
                             DataCatalogAttributeNormalizer.format_name(
                                 column_name)
                         entry_columns.append(
-                            datacatalog.ColumnSchema(
-                                column=column_name,
-                                description=column_desc,
-                                type=data_type))
+                            datacatalog.ColumnSchema(column=column_name,
+                                                     description=column_desc,
+                                                     type=data_type))
         entry.schema.columns.extend(entry_columns)

--- a/google-datacatalog-apache-atlas-connector/src/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-apache-atlas-connector/src/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_entry_factory.py
@@ -17,7 +17,7 @@
 import logging
 
 from google.cloud import datacatalog
-from google.cloud.datacatalog import types
+from google.protobuf import timestamp_pb2
 from google.datacatalog_connectors.commons import prepare
 
 from google.datacatalog_connectors.apache_atlas.prepare import \
@@ -39,7 +39,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         self.__server_id = instance_url[instance_url.find('//') + 2:]
 
     def make_entry_for_entity(self, entity):
-        entry = types.Entry()
+        entry = datacatalog.Entry()
 
         guid = entity['guid']
         data = entity['data']
@@ -113,15 +113,19 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         update_time = data.get('updateTime')
         if create_time:
             # Transform millis to seconds.
-            entry.source_system_timestamps.create_time.seconds = round(
-                create_time / 1000)
+            created_timestamp = timestamp_pb2.Timestamp()
+            created_timestamp.FromSeconds(round(create_time / 1000))
+
+            entry.source_system_timestamps.create_time = created_timestamp
 
             if not update_time:
                 update_time = create_time
 
-            # Transform millis to seconds. ADD 10 seconds because
-            entry.source_system_timestamps.update_time.seconds = round(
-                update_time / 1000)
+            # Transform millis to seconds.
+            updated_timestamp = timestamp_pb2.Timestamp()
+            updated_timestamp.FromSeconds(round(update_time / 1000))
+
+            entry.source_system_timestamps.update_time = updated_timestamp
         else:
             logging.info('Entity "%s" has no created_time information!',
                          generated_id)
@@ -144,9 +148,8 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
                             DataCatalogAttributeNormalizer.format_name(
                                 column_name)
                         entry_columns.append(
-                            datacatalog.types.ColumnSchema(
+                            datacatalog.ColumnSchema(
                                 column=column_name,
                                 description=column_desc,
-                                type=data_type,
-                                mode=None))
+                                type=data_type))
         entry.schema.columns.extend(entry_columns)

--- a/google-datacatalog-apache-atlas-connector/src/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-apache-atlas-connector/src/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_tag_factory.py
@@ -17,7 +17,6 @@
 import copy
 
 from google.cloud import datacatalog
-from google.cloud.datacatalog import types
 from google.datacatalog_connectors.commons import prepare
 
 from google.datacatalog_connectors.apache_atlas.prepare import constant
@@ -43,7 +42,7 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
                                     classifications,
                                     enum_types_dict,
                                     column_name=None):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
 
         classification_name = entity_classification['typeName']
 
@@ -79,7 +78,7 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         return tag
 
     def make_tag_for_column_ref(self, column_guid, column_name):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
 
         tag_template_id = attr_normalizer.DataCatalogAttributeNormalizer.\
             create_tag_template_id('ref', constant.COLUMN_PREFIX)
@@ -97,7 +96,7 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         return tag
 
     def make_tag_for_entity(self, entity, entity_types_dict, enum_types_dict):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
 
         guid = entity['guid']
         data = entity['data']
@@ -174,7 +173,9 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
                     super()._set_string_field(tag, formatted_name,
                                               str(tag_value))
             elif enum_type:
-                tag.fields[formatted_name].enum_value.display_name = tag_value
+                enum_field = datacatalog.TagField()
+                enum_field.enum_value.display_name = tag_value
+                tag.fields[formatted_name] = enum_field
             else:
                 super()._set_string_field(tag, formatted_name, str(tag_value))
 

--- a/google-datacatalog-apache-atlas-connector/src/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-apache-atlas-connector/src/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_tag_template_factory.py
@@ -71,9 +71,10 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
 
         tag_template.display_name = 'Column'
 
-        self._add_primitive_type_field(tag_template, 'column_guid', self.__STRING_TYPE,
-                                       'column guid')
-        self._add_primitive_type_field(tag_template, 'column_entry', self.__STRING_TYPE,
+        self._add_primitive_type_field(tag_template, 'column_guid',
+                                       self.__STRING_TYPE, 'column guid')
+        self._add_primitive_type_field(tag_template, 'column_entry',
+                                       self.__STRING_TYPE,
                                        'column data catalog entry')
 
         return {tag_template_id: tag_template}
@@ -130,8 +131,8 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
         self.__add_fields_from_attribute_defs(tag_template, attribute_defs,
                                               enum_types_dict)
 
-        self._add_primitive_type_field(tag_template, formatted_name, self.__BOOL_TYPE,
-                                       formatted_name)
+        self._add_primitive_type_field(tag_template, formatted_name,
+                                       self.__BOOL_TYPE, formatted_name)
 
         return {tag_template_id: tag_template}
 
@@ -166,13 +167,14 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
         self.__add_fields_from_attribute_defs(tag_template, attribute_defs,
                                               enum_types_dict)
 
-        self._add_primitive_type_field(tag_template, formatted_name, self.__BOOL_TYPE,
-                                       formatted_name)
+        self._add_primitive_type_field(tag_template, formatted_name,
+                                       self.__BOOL_TYPE, formatted_name)
 
-        self._add_primitive_type_field(tag_template, constant.ENTITY_GUID, self.__STRING_TYPE,
-                                       'entity guid')
+        self._add_primitive_type_field(tag_template, constant.ENTITY_GUID,
+                                       self.__STRING_TYPE, 'entity guid')
 
-        self._add_primitive_type_field(tag_template, constant.INSTANCE_URL_FIELD,
+        self._add_primitive_type_field(tag_template,
+                                       constant.INSTANCE_URL_FIELD,
                                        self.__STRING_TYPE, 'instance url')
 
         self.__create_custom_fields_for_entity_type(tag_template,
@@ -248,34 +250,36 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
     def __create_custom_fields_for_table_type(self, tag_template):
         self.__add_db_fields(tag_template)
 
-        self._add_primitive_type_field(tag_template, 'sd_guid', self.__STRING_TYPE,
-                                       'sd guid')
+        self._add_primitive_type_field(tag_template, 'sd_guid',
+                                       self.__STRING_TYPE, 'sd guid')
 
-        self._add_primitive_type_field(tag_template, 'sd_entry', self.__STRING_TYPE,
+        self._add_primitive_type_field(tag_template, 'sd_entry',
+                                       self.__STRING_TYPE,
                                        'sd data catalog entry')
 
     def __add_db_fields(self, tag_template):
 
-        self._add_primitive_type_field(tag_template, 'db_name', self.__STRING_TYPE,
-                                       'db name')
+        self._add_primitive_type_field(tag_template, 'db_name',
+                                       self.__STRING_TYPE, 'db name')
 
-        self._add_primitive_type_field(tag_template, 'db_guid', self.__STRING_TYPE,
-                                       'db guid')
+        self._add_primitive_type_field(tag_template, 'db_guid',
+                                       self.__STRING_TYPE, 'db guid')
 
-        self._add_primitive_type_field(tag_template, 'db_entry', self.__STRING_TYPE,
+        self._add_primitive_type_field(tag_template, 'db_entry',
+                                       self.__STRING_TYPE,
                                        'db data catalog entry')
 
     def __create_custom_fields_for_view_type(self, tag_template):
         self.__add_db_fields(tag_template)
 
-        self._add_primitive_type_field(tag_template, 'input_tables_names', self.__STRING_TYPE,
+        self._add_primitive_type_field(tag_template, 'input_tables_names',
+                                       self.__STRING_TYPE,
                                        'input tables names')
 
     def __create_custom_fields_for_load_process_type(self, tag_template):
 
-        self._add_primitive_type_field(tag_template, 'inputs_names', self.__STRING_TYPE,
-                                       'inputs names')
+        self._add_primitive_type_field(tag_template, 'inputs_names',
+                                       self.__STRING_TYPE, 'inputs names')
 
-        self._add_primitive_type_field(tag_template, 'outputs_names', self.__STRING_TYPE,
-                                       'outputs names')
-
+        self._add_primitive_type_field(tag_template, 'outputs_names',
+                                       self.__STRING_TYPE, 'outputs names')

--- a/google-datacatalog-apache-atlas-connector/src/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-apache-atlas-connector/src/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_tag_template_factory.py
@@ -15,19 +15,20 @@
 # limitations under the License.
 
 from google.cloud import datacatalog
-from google.cloud.datacatalog import enums, types
+
+from google.datacatalog_connectors.commons import prepare
 
 from google.datacatalog_connectors.apache_atlas.prepare import constant
 from google.datacatalog_connectors.apache_atlas.prepare import \
     datacatalog_attribute_normalizer as attr_normalizer
 
 
-class DataCatalogTagTemplateFactory:
+class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
 
-    __BOOL_TYPE = enums.FieldType.PrimitiveType.BOOL
-    __DOUBLE_TYPE = enums.FieldType.PrimitiveType.DOUBLE
-    __STRING_TYPE = enums.FieldType.PrimitiveType.STRING
-    __TIMESTAMP_TYPE = enums.FieldType.PrimitiveType.TIMESTAMP
+    __BOOL_TYPE = datacatalog.FieldType.PrimitiveType.BOOL
+    __DOUBLE_TYPE = datacatalog.FieldType.PrimitiveType.DOUBLE
+    __STRING_TYPE = datacatalog.FieldType.PrimitiveType.STRING
+    __TIMESTAMP_TYPE = datacatalog.FieldType.PrimitiveType.TIMESTAMP
 
     def __init__(self, project_id, location_id):
         self.__project_id = project_id
@@ -60,7 +61,7 @@ class DataCatalogTagTemplateFactory:
         return tag_templates
 
     def make_column_tag_template(self):
-        tag_template = types.TagTemplate()
+        tag_template = datacatalog.TagTemplate()
 
         tag_template_id = attr_normalizer.DataCatalogAttributeNormalizer.\
             create_tag_template_id(
@@ -70,13 +71,10 @@ class DataCatalogTagTemplateFactory:
 
         tag_template.display_name = 'Column'
 
-        tag_template.fields[
-            'column_guid'].type.primitive_type = self.__STRING_TYPE
-        tag_template.fields['column_guid'].display_name = 'column guid'
-        tag_template.fields[
-            'column_entry'].type.primitive_type = self.__STRING_TYPE
-        tag_template.fields[
-            'column_entry'].display_name = 'column data catalog entry'
+        self._add_primitive_type_field(tag_template, 'column_guid', self.__STRING_TYPE,
+                                       'column guid')
+        self._add_primitive_type_field(tag_template, 'column_entry', self.__STRING_TYPE,
+                                       'column data catalog entry')
 
         return {tag_template_id: tag_template}
 
@@ -101,7 +99,7 @@ class DataCatalogTagTemplateFactory:
     def __create_classification_tag_template(self, classification_dict,
                                              classifications_dict,
                                              enum_types_dict):
-        tag_template = types.TagTemplate()
+        tag_template = datacatalog.TagTemplate()
 
         classification_data = classification_dict['data']
 
@@ -132,15 +130,14 @@ class DataCatalogTagTemplateFactory:
         self.__add_fields_from_attribute_defs(tag_template, attribute_defs,
                                               enum_types_dict)
 
-        tag_template.fields[
-            formatted_name].type.primitive_type = self.__BOOL_TYPE
-        tag_template.fields[formatted_name].display_name = formatted_name
+        self._add_primitive_type_field(tag_template, formatted_name, self.__BOOL_TYPE,
+                                       formatted_name)
 
         return {tag_template_id: tag_template}
 
     def __create_entity_type_tag_template(self, entity_type_dict,
                                           entity_types_dict, enum_types_dict):
-        tag_template = types.TagTemplate()
+        tag_template = datacatalog.TagTemplate()
 
         entity_type_data = entity_type_dict['data']
         name = entity_type_data['name']
@@ -169,19 +166,14 @@ class DataCatalogTagTemplateFactory:
         self.__add_fields_from_attribute_defs(tag_template, attribute_defs,
                                               enum_types_dict)
 
-        tag_template.fields[
-            formatted_name].type.primitive_type = self.__BOOL_TYPE
-        tag_template.fields[formatted_name].display_name = formatted_name
+        self._add_primitive_type_field(tag_template, formatted_name, self.__BOOL_TYPE,
+                                       formatted_name)
 
-        tag_template.fields[
-            constant.ENTITY_GUID].type.primitive_type = self.__STRING_TYPE
-        tag_template.fields[constant.ENTITY_GUID].display_name = 'entity guid'
+        self._add_primitive_type_field(tag_template, constant.ENTITY_GUID, self.__STRING_TYPE,
+                                       'entity guid')
 
-        tag_template.fields[
-            constant.
-            INSTANCE_URL_FIELD].type.primitive_type = self.__STRING_TYPE
-        tag_template.fields[
-            constant.INSTANCE_URL_FIELD].display_name = 'instance url'
+        self._add_primitive_type_field(tag_template, constant.INSTANCE_URL_FIELD,
+                                       self.__STRING_TYPE, 'instance url')
 
         self.__create_custom_fields_for_entity_type(tag_template,
                                                     entity_type_data)
@@ -201,6 +193,10 @@ class DataCatalogTagTemplateFactory:
             format_name(name)
         type_name = attribute_def['typeName']
         enum_type = enum_types_dict.get(type_name)
+
+        field = datacatalog.TagTemplateField()
+        field.display_name = name
+
         if type_name in constant.DATACATALOG_TARGET_PRIMITIVE_TYPES:
             if type_name in constant.DATACATALOG_TARGET_DOUBLE_TYPE:
                 target_type = self.__DOUBLE_TYPE
@@ -209,20 +205,18 @@ class DataCatalogTagTemplateFactory:
             else:
                 target_type = self.__STRING_TYPE
 
-            tag_template.fields[
-                formatted_name].type.primitive_type = target_type
+            field.type.primitive_type = target_type
         elif enum_type:
             enum_element_defs = enum_type['data']['elementDefs']
             for enum_element_def in enum_element_defs:
-                tag_template.fields[formatted_name].type.enum_type\
-                    .allowed_values.add().display_name =\
-                    enum_element_def['value']
+                enum_value = datacatalog.FieldType.EnumType.EnumValue()
+                enum_value.display_name = enum_element_def['value']
+                field.type.enum_type.allowed_values.append(enum_value)
         else:
             # String is the default type.
-            tag_template.fields[
-                formatted_name].type.primitive_type = self.__STRING_TYPE
+            field.type.primitive_type = self.__STRING_TYPE
 
-        tag_template.fields[formatted_name].display_name = name
+        tag_template.fields[formatted_name] = field
 
     def __add_fields_from_super_types(self, tag_template, super_types,
                                       types_dict, enum_types_dict):
@@ -254,37 +248,34 @@ class DataCatalogTagTemplateFactory:
     def __create_custom_fields_for_table_type(self, tag_template):
         self.__add_db_fields(tag_template)
 
-        tag_template.fields['sd_guid'].type.primitive_type =\
-            self.__STRING_TYPE
-        tag_template.fields['sd_guid'].display_name = 'sd guid'
+        self._add_primitive_type_field(tag_template, 'sd_guid', self.__STRING_TYPE,
+                                       'sd guid')
 
-        tag_template.fields[
-            'sd_entry'].type.primitive_type = self.__STRING_TYPE
-        tag_template.fields['sd_entry'].display_name = 'sd data catalog entry'
+        self._add_primitive_type_field(tag_template, 'sd_entry', self.__STRING_TYPE,
+                                       'sd data catalog entry')
 
     def __add_db_fields(self, tag_template):
-        tag_template.fields['db_name'].type.primitive_type =\
-            self.__STRING_TYPE
-        tag_template.fields['db_name'].display_name = 'db name'
-        tag_template.fields['db_guid'].type.primitive_type =\
-            self.__STRING_TYPE
-        tag_template.fields['db_guid'].display_name = 'db guid'
-        tag_template.fields[
-            'db_entry'].type.primitive_type = self.__STRING_TYPE
-        tag_template.fields['db_entry'].display_name = 'db data catalog entry'
+
+        self._add_primitive_type_field(tag_template, 'db_name', self.__STRING_TYPE,
+                                       'db name')
+
+        self._add_primitive_type_field(tag_template, 'db_guid', self.__STRING_TYPE,
+                                       'db guid')
+
+        self._add_primitive_type_field(tag_template, 'db_entry', self.__STRING_TYPE,
+                                       'db data catalog entry')
 
     def __create_custom_fields_for_view_type(self, tag_template):
         self.__add_db_fields(tag_template)
 
-        tag_template.fields[
-            'input_tables_names'].type.primitive_type = self.__STRING_TYPE
-        tag_template.fields[
-            'input_tables_names'].display_name = 'input tables names'
+        self._add_primitive_type_field(tag_template, 'input_tables_names', self.__STRING_TYPE,
+                                       'input tables names')
 
     def __create_custom_fields_for_load_process_type(self, tag_template):
-        tag_template.fields[
-            'inputs_names'].type.primitive_type = self.__STRING_TYPE
-        tag_template.fields['inputs_names'].display_name = 'inputs names'
-        tag_template.fields[
-            'outputs_names'].type.primitive_type = self.__STRING_TYPE
-        tag_template.fields['outputs_names'].display_name = 'outputs names'
+
+        self._add_primitive_type_field(tag_template, 'inputs_names', self.__STRING_TYPE,
+                                       'inputs names')
+
+        self._add_primitive_type_field(tag_template, 'outputs_names', self.__STRING_TYPE,
+                                       'outputs names')
+

--- a/google-datacatalog-apache-atlas-connector/src/google/datacatalog_connectors/apache_atlas/sync/metadata_event_synchronizer.py
+++ b/google-datacatalog-apache-atlas-connector/src/google/datacatalog_connectors/apache_atlas/sync/metadata_event_synchronizer.py
@@ -17,7 +17,7 @@
 import logging
 from time import sleep
 
-from google.cloud.datacatalog import enums
+from google.cloud import datacatalog
 from google.datacatalog_connectors.commons import \
     datacatalog_facade
 
@@ -29,7 +29,7 @@ from google.datacatalog_connectors.apache_atlas.sync import \
 
 class MetadataEventSynchronizer(metadata_synchronizer.MetadataSynchronizer):
     __EVENT_POLL_SLEEP_TIME_SECONDS = 5
-    __STRING_TYPE = enums.FieldType.PrimitiveType.STRING
+    __STRING_TYPE = datacatalog.FieldType.PrimitiveType.STRING
 
     def __init__(self,
                  datacatalog_project_id,

--- a/google-datacatalog-apache-atlas-connector/system_tests/execution_results_test.py
+++ b/google-datacatalog-apache-atlas-connector/system_tests/execution_results_test.py
@@ -18,22 +18,26 @@ import os
 import unittest
 
 from google.cloud import datacatalog
-from google.cloud.datacatalog import types
 
-datacatalog = datacatalog.DataCatalogClient()
+datacatalog_client = datacatalog.DataCatalogClient()
 
 
 class ExecutionResultsTest(unittest.TestCase):
 
-    def test_tableau_entries_should_exist_after_connector_execution(self):
+    def test_entries_should_exist_after_connector_execution(self):
         query = 'system=apache-atlas'
 
-        scope = types.SearchCatalogRequest.Scope()
+        scope = datacatalog.SearchCatalogRequest.Scope()
         scope.include_project_ids.append(
             os.environ['APACHE_ATLAS2DC_DATACATALOG_PROJECT_ID'])
 
+        request = datacatalog.SearchCatalogRequest()
+        request.scope = scope
+        request.query = query
+        request.page_size = 1000
+
         search_results = [
-            result for result in datacatalog.search_catalog(
-                scope=scope, query=query, order_by='relevance', page_size=1000)
+            result for result in datacatalog_client.search_catalog(request)
         ]
         self.assertGreater(len(search_results), 0)
+

--- a/google-datacatalog-apache-atlas-connector/tests/google/datacatalog_connectors/apache_atlas/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-apache-atlas-connector/tests/google/datacatalog_connectors/apache_atlas/prepare/assembled_entry_factory_test.py
@@ -18,7 +18,7 @@ import os
 import unittest
 from unittest import mock
 
-from google.cloud.datacatalog import types
+from google.cloud import datacatalog
 from google.datacatalog_connectors.commons_test import utils
 
 from google.datacatalog_connectors.apache_atlas import prepare
@@ -161,21 +161,21 @@ class AssembledEntryFactoryTest(unittest.TestCase):
 
     @classmethod
     def __mock_make_entry(cls, entity):
-        entry = types.Entry()
+        entry = datacatalog.Entry()
         entry_id = entity['guid']
         entry.name = 'fake_entries/{}'.format(entry_id)
         return entry_id, entry
 
     @classmethod
     def __mock_make_tag(cls, entity, *_):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
         tag.template = 'fake_template/entity_type/{}'.format(
             entity['data']['typeName'])
         return tag
 
     @classmethod
     def __mock_make_tag_classification(cls, classification, *args):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
 
         template = 'fake_template/{}'.format(classification['typeName'])
 
@@ -187,6 +187,6 @@ class AssembledEntryFactoryTest(unittest.TestCase):
 
     @classmethod
     def __mock_make_tag_for_column_ref(cls, column_guid, _):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
         tag.template = 'fake_template/{}/column_ref'.format(column_guid)
         return tag

--- a/google-datacatalog-apache-atlas-connector/tests/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-apache-atlas-connector/tests/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_entry_factory_test.py
@@ -64,10 +64,12 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'table_2286a6bd_4b06_4f7c_a666_920d774b040e',
             entry.linked_resource)
 
-        self.assertEqual(1589983836.0,
-                         entry.source_system_timestamps.create_time.timestamp())
-        self.assertEqual(1589983851.0,
-                         entry.source_system_timestamps.update_time.timestamp())
+        self.assertEqual(
+            1589983836.0,
+            entry.source_system_timestamps.create_time.timestamp())
+        self.assertEqual(
+            1589983851.0,
+            entry.source_system_timestamps.update_time.timestamp())
 
         columns = entry.schema.columns
         self.assertEqual(4, len(columns))
@@ -116,10 +118,12 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('//my_entry_specified_location',
                          entry.linked_resource)
 
-        self.assertEqual(1589983836.0,
-                         entry.source_system_timestamps.create_time.timestamp())
-        self.assertEqual(1589983836.0,
-                         entry.source_system_timestamps.update_time.timestamp())
+        self.assertEqual(
+            1589983836.0,
+            entry.source_system_timestamps.create_time.timestamp())
+        self.assertEqual(
+            1589983836.0,
+            entry.source_system_timestamps.update_time.timestamp())
 
         columns = entry.schema.columns
         self.assertEqual(4, len(columns))

--- a/google-datacatalog-apache-atlas-connector/tests/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-apache-atlas-connector/tests/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_entry_factory_test.py
@@ -64,10 +64,10 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'table_2286a6bd_4b06_4f7c_a666_920d774b040e',
             entry.linked_resource)
 
-        self.assertEqual(1589983836,
-                         entry.source_system_timestamps.create_time.seconds)
-        self.assertEqual(1589983851,
-                         entry.source_system_timestamps.update_time.seconds)
+        self.assertEqual(1589983836.0,
+                         entry.source_system_timestamps.create_time.timestamp())
+        self.assertEqual(1589983851.0,
+                         entry.source_system_timestamps.update_time.timestamp())
 
         columns = entry.schema.columns
         self.assertEqual(4, len(columns))
@@ -116,10 +116,10 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('//my_entry_specified_location',
                          entry.linked_resource)
 
-        self.assertEqual(1589983836,
-                         entry.source_system_timestamps.create_time.seconds)
-        self.assertEqual(1589983836,
-                         entry.source_system_timestamps.update_time.seconds)
+        self.assertEqual(1589983836.0,
+                         entry.source_system_timestamps.create_time.timestamp())
+        self.assertEqual(1589983836.0,
+                         entry.source_system_timestamps.update_time.timestamp())
 
         columns = entry.schema.columns
         self.assertEqual(4, len(columns))

--- a/google-datacatalog-apache-atlas-connector/tests/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-apache-atlas-connector/tests/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_tag_factory_test.py
@@ -222,7 +222,7 @@ class DataCatalogTagFactoryTest(unittest.TestCase):
         self.assertEqual(True, tag.fields['view'].bool_value)
         self.assertEqual('55a5f51f-1b21-4742-9059-818b7531df85',
                          tag.fields['guid'].string_value)
-        self.assertEqual('', tag.fields['owner'].string_value)
+        self.assertIsNone(tag.fields.get('owner'))
         self.assertEqual('customer_dim',
                          tag.fields['input_tables_names'].string_value)
         self.assertEqual('https://test.server.com',
@@ -273,7 +273,7 @@ class DataCatalogTagFactoryTest(unittest.TestCase):
         self.assertEqual(True, tag.fields['loadprocess'].bool_value)
         self.assertEqual('e73656c9-da05-4db7-9b88-e3669c1a98eb',
                          tag.fields['guid'].string_value)
-        self.assertEqual('', tag.fields['owner'].string_value)
+        self.assertIsNone(tag.fields.get('owner'))
         self.assertEqual('log_fact_daily_mv',
                          tag.fields['inputs_names'].string_value)
         self.assertEqual(

--- a/google-datacatalog-apache-atlas-connector/tests/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-apache-atlas-connector/tests/google/datacatalog_connectors/apache_atlas/prepare/datacatalog_tag_template_factory_test.py
@@ -27,10 +27,10 @@ from google.datacatalog_connectors.apache_atlas.prepare import \
 class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
     __MODULE_PATH = os.path.dirname(os.path.abspath(__file__))
 
-    __BOOL_TYPE = datacatalog.enums.FieldType.PrimitiveType.BOOL
-    __DOUBLE_TYPE = datacatalog.enums.FieldType.PrimitiveType.DOUBLE
-    __STRING_TYPE = datacatalog.enums.FieldType.PrimitiveType.STRING
-    __TIMESTAMP_TYPE = datacatalog.enums.FieldType.PrimitiveType.TIMESTAMP
+    __BOOL_TYPE = datacatalog.FieldType.PrimitiveType.BOOL
+    __DOUBLE_TYPE = datacatalog.FieldType.PrimitiveType.DOUBLE
+    __STRING_TYPE = datacatalog.FieldType.PrimitiveType.STRING
+    __TIMESTAMP_TYPE = datacatalog.FieldType.PrimitiveType.TIMESTAMP
 
     def setUp(self):
         self.__factory = datacatalog_tag_template_factory. \

--- a/google-datacatalog-apache-atlas-connector/tests/google/datacatalog_connectors/apache_atlas/prepare/entry_relationship_mapper_test.py
+++ b/google-datacatalog-apache-atlas-connector/tests/google/datacatalog_connectors/apache_atlas/prepare/entry_relationship_mapper_test.py
@@ -16,7 +16,7 @@
 
 import unittest
 
-from google.cloud.datacatalog import types
+from google.cloud import datacatalog
 from google.datacatalog_connectors.commons import \
     prepare as commons_prepare
 
@@ -99,21 +99,25 @@ class EntryRelationshipMapperTest(unittest.TestCase):
 
     @classmethod
     def __make_fake_entry(cls, entry_id, entry_type):
-        entry = types.Entry()
+        entry = datacatalog.Entry()
         entry.name = 'fake_entries/{}'.format(entry_id)
         entry.user_specified_type = entry_type
         return entry
 
     @classmethod
     def __make_fake_tag(cls, string_fields=None, double_fields=None):
-        tag = types.Tag()
+        tag = datacatalog.Tag()
 
         if string_fields:
             for field in string_fields:
-                tag.fields[field[0]].string_value = field[1]
+                string_field = datacatalog.TagField()
+                string_field.string_value = field[1]
+                tag.fields[field[0]] = string_field
 
         if double_fields:
             for field in double_fields:
-                tag.fields[field[0]].double_value = field[1]
+                double_field = datacatalog.TagField()
+                double_field.double_value = field[1]
+                tag.fields[field[0]] = double_field
 
         return tag

--- a/google-datacatalog-hive-connector/setup.py
+++ b/google-datacatalog-hive-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-hive-connector',
-    version='0.6.1',
+    version='0.7.0',
     author='Google LLC',
     description=
     'Library for ingesting Hive metadata into Google Cloud Data Catalog',
@@ -41,10 +41,10 @@ setuptools.setup(
         'psycopg2-binary',
         'mysqlclient',
         'sqlalchemy',
-        'google-datacatalog-connectors-commons>=0.5.2,<0.6.0',
+        'google-datacatalog-connectors-commons>=0.6.0',
     ),
     setup_requires=('pytest-runner',),
-    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test>=0.5.1,<0.6.0'),
+    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test>=0.6.0'),
     classifiers=(
         release_status,
         'Programming Language :: Python :: 3.7',

--- a/google-datacatalog-hive-connector/system_tests/execution_results_test.py
+++ b/google-datacatalog-hive-connector/system_tests/execution_results_test.py
@@ -18,22 +18,25 @@ import os
 import unittest
 
 from google.cloud import datacatalog
-from google.cloud.datacatalog import types
 
-datacatalog = datacatalog.DataCatalogClient()
+datacatalog_client = datacatalog.DataCatalogClient()
 
 
 class ExecutionResultsTest(unittest.TestCase):
 
-    def test_tableau_entries_should_exist_after_connector_execution(self):
+    def test_entries_should_exist_after_connector_execution(self):
         query = 'system=hive'
 
-        scope = types.SearchCatalogRequest.Scope()
+        scope = datacatalog.SearchCatalogRequest.Scope()
         scope.include_project_ids.append(
             os.environ['HIVE2DC_DATACATALOG_PROJECT_ID'])
 
+        request = datacatalog.SearchCatalogRequest()
+        request.scope = scope
+        request.query = query
+        request.page_size = 1000
+
         search_results = [
-            result for result in datacatalog.search_catalog(
-                scope=scope, query=query, order_by='relevance', page_size=1000)
+            result for result in datacatalog_client.search_catalog(request)
         ]
         self.assertGreater(len(search_results), 0)

--- a/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/assembled_entry_factory_test.py
@@ -108,10 +108,12 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
                 self.assertEqual('default__funds', assembled_table.entry_id)
                 self.assertEqual(
                     1567519048.0,
-                    table_entry.source_system_timestamps.create_time.timestamp())
+                    table_entry.source_system_timestamps.create_time.timestamp(
+                    ))
                 self.assertEqual(
                     1567519078.0,
-                    table_entry.source_system_timestamps.update_time.timestamp())
+                    table_entry.source_system_timestamps.update_time.timestamp(
+                    ))
                 # Assert specific fields for table
                 self.assertEqual('table', table_entry.user_specified_type)
                 self.assertEqual('hive', table_entry.user_specified_system)
@@ -192,10 +194,10 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
                 table_entry = user_defined_table.entry
                 self.__assert_required(user_defined_table.entry_id,
                                        table_entry)
-                self.assertIsNotNone(
-                    table_entry.source_system_timestamps.create_time.timestamp())
-                self.assertIsNotNone(
-                    table_entry.source_system_timestamps.update_time.timestamp())
+                self.assertIsNotNone(table_entry.source_system_timestamps.
+                                     create_time.timestamp())
+                self.assertIsNotNone(table_entry.source_system_timestamps.
+                                     update_time.timestamp())
                 # Assert specific fields for table
                 self.assertEqual('table', table_entry.user_specified_type)
                 self.assertEqual('hive', table_entry.user_specified_system)

--- a/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/assembled_entry_factory_test.py
@@ -107,11 +107,11 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
                 table_entry = assembled_table.entry
                 self.assertEqual('default__funds', assembled_table.entry_id)
                 self.assertEqual(
-                    1567519048,
-                    table_entry.source_system_timestamps.create_time.seconds)
+                    1567519048.0,
+                    table_entry.source_system_timestamps.create_time.timestamp())
                 self.assertEqual(
-                    1567519078,
-                    table_entry.source_system_timestamps.update_time.seconds)
+                    1567519078.0,
+                    table_entry.source_system_timestamps.update_time.timestamp())
                 # Assert specific fields for table
                 self.assertEqual('table', table_entry.user_specified_type)
                 self.assertEqual('hive', table_entry.user_specified_system)
@@ -193,9 +193,9 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
                 self.__assert_required(user_defined_table.entry_id,
                                        table_entry)
                 self.assertIsNotNone(
-                    table_entry.source_system_timestamps.create_time.seconds)
+                    table_entry.source_system_timestamps.create_time.timestamp())
                 self.assertIsNotNone(
-                    table_entry.source_system_timestamps.update_time.seconds)
+                    table_entry.source_system_timestamps.update_time.timestamp())
                 # Assert specific fields for table
                 self.assertEqual('table', table_entry.user_specified_type)
                 self.assertEqual('hive', table_entry.user_specified_system)

--- a/tools/publish-current-versions-pypi.sh
+++ b/tools/publish-current-versions-pypi.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR=$(pwd)
+
+publish-current-versions-pypi::main(){
+
+    if [[ -z "${PYPI_DATACATALOG_MAINTAINER_USERNAME}" ]]; then
+        publish-current-versions-pypi::usage
+    fi
+
+    if [[ -z "${PYPI_DATACATALOG_MAINTAINER_PASSWORD}" ]]; then
+        publish-current-versions-pypi::usage
+    fi
+
+    echo "START publish to pypi current versions script"
+    echo ""
+
+    # Ignore error message if dir does not exist
+    rm -rf publish_pypi_env 2> /dev/null || echo > /dev/null
+
+    virtualenv publish_pypi_env --python python3
+
+    source publish_pypi_env/bin/activate
+
+    pip install twine
+
+    for connector_dir in `ls ${CURRENT_DIR} | grep connector`; do
+        cd ${CURRENT_DIR}/${connector_dir}
+        echo " running on: ${connector_dir}"
+
+        rm -rf dist && \
+        python3 setup.py sdist bdist_wheel --universal && \
+        twine upload dist/* \
+        -u ${PYPI_DATACATALOG_MAINTAINER_USERNAME} \
+        -p ${PYPI_DATACATALOG_MAINTAINER_PASSWORD}
+
+        if [[ $? -eq 0 ]]
+            then
+                echo " ${connector_dir} published to PyPI!"
+            else
+                echo " ${connector_dir} publishing failed!"
+        fi
+
+        echo ""
+    done
+
+    echo "END publish to pypi current versions script"
+}
+
+publish-current-versions-pypi::usage(){
+  echo 'Please set the "PYPI_DATACATALOG_MAINTAINER_USERNAME" and "PYPI_DATACATALOG_MAINTAINER_PASSWORD" environment variables before running this script'
+  exit 2
+}
+
+publish-current-versions-pypi::main "$@"


### PR DESCRIPTION
**- What I did**
Updated the code to make compatible with the Data Catalog client library v2.0.0

**- How I did it**
Followed the instructions from the [2.0.0 Migration Guide](https://github.com/googleapis/python-datacatalog/blob/master/UPGRADING.md) and other changes not covered in that guide.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Upgrade datacatalog client library version to 2.0.0