### PR TITLE
Remove Python 3.6 temporary from CI.

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         build-dir: ['./google-datacatalog-hive-connector', './google-datacatalog-apache-atlas-connector']
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
     defaults:
       run:
         working-directory: ${{ matrix.build-dir }}


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-hive/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Removed Python 3.6 temporary from CI.

**- How I did it**
Removed Python 3.6 temporary from CI.

**- How to verify it**
Run the CI.

**- Description for the changelog**
The dependency used by the pandas library `numpy-1.20.0rc1`, dropped support for Python 3.6. 
See if there is an alternative in a subsequent PR to enable Python 3.6.
