### PR TITLE
Improve session clean up and connection pool handling

### DIFF
--- a/google-datacatalog-hive-connector/setup.py
+++ b/google-datacatalog-hive-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-hive-connector',
-    version='0.8.0',
+    version='0.8.1',
     author='Google LLC',
     description=
     'Library for ingesting Hive metadata into Google Cloud Data Catalog',

--- a/google-datacatalog-hive-connector/src/google/datacatalog_connectors/hive/scrape/metadata_database_scraper.py
+++ b/google-datacatalog-hive-connector/src/google/datacatalog_connectors/hive/scrape/metadata_database_scraper.py
@@ -18,8 +18,7 @@ from contextlib import contextmanager
 import logging
 
 from google.datacatalog_connectors.hive import entities
-from sqlalchemy import create_engine
-from sqlalchemy import exc
+from sqlalchemy import create_engine, exc
 from sqlalchemy.orm import subqueryload, sessionmaker
 
 
@@ -31,11 +30,12 @@ class MetadataDatabaseScraper:
     def __init__(self, hive_metastore_db_host, hive_metastore_db_user,
                  hive_metastore_db_pass, hive_metastore_db_name,
                  hive_metastore_db_type):
+        # yapf: disable
         self.__engine = create_engine('{}://{}:{}@{}/{}'.format(
             hive_metastore_db_type, hive_metastore_db_user,
             hive_metastore_db_pass, hive_metastore_db_host,
-            hive_metastore_db_name),
-                                      pool_size=self.CONNECTION_POOL_SIZE)
+            hive_metastore_db_name), pool_size=self.CONNECTION_POOL_SIZE)
+        # yapf: enable
 
     def get_database_metadata(self):
         try:

--- a/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/scrape/metadata_database_scraper_test.py
+++ b/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/scrape/metadata_database_scraper_test.py
@@ -51,9 +51,6 @@ class MetadataScraperTestCase(unittest.TestCase):
         mocked_session.options.return_value = mocked_session
         mocked_session.offset.return_value = mocked_session
 
-        # Mock context creation
-        mocked_session.__enter__.return_value = mocked_session
-
         # Mocks with 2 pages, and third page is empty.
         mocked_session.all.side_effect = [
             retrieve_json_file('databases.json'),
@@ -87,9 +84,6 @@ class MetadataScraperTestCase(unittest.TestCase):
         mocked_session.options.return_value = mocked_session
         mocked_session.offset.return_value = mocked_session
 
-        # Mock context creation
-        mocked_session.__enter__.return_value = mocked_session
-
         mocked_session.all.return_value = []
 
         sessionmaker.return_value = mocked_session
@@ -118,9 +112,6 @@ class MetadataScraperTestCase(unittest.TestCase):
         mocked_session.limit.return_value = mocked_session
         mocked_session.options.return_value = mocked_session
         mocked_session.offset.return_value = mocked_session
-
-        # Mock context creation
-        mocked_session.__enter__.return_value = mocked_session
 
         mocked_session.all.side_effect = exc.OperationalError(
             statement='SQL QUERY', params=[], orig=1)

--- a/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/scrape/metadata_database_scraper_test.py
+++ b/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/scrape/metadata_database_scraper_test.py
@@ -51,6 +51,9 @@ class MetadataScraperTestCase(unittest.TestCase):
         mocked_session.options.return_value = mocked_session
         mocked_session.offset.return_value = mocked_session
 
+        # Mock context creation
+        mocked_session.__enter__.return_value = mocked_session
+
         # Mocks with 2 pages, and third page is empty.
         mocked_session.all.side_effect = [
             retrieve_json_file('databases.json'),
@@ -84,6 +87,9 @@ class MetadataScraperTestCase(unittest.TestCase):
         mocked_session.options.return_value = mocked_session
         mocked_session.offset.return_value = mocked_session
 
+        # Mock context creation
+        mocked_session.__enter__.return_value = mocked_session
+
         mocked_session.all.return_value = []
 
         sessionmaker.return_value = mocked_session
@@ -112,6 +118,9 @@ class MetadataScraperTestCase(unittest.TestCase):
         mocked_session.limit.return_value = mocked_session
         mocked_session.options.return_value = mocked_session
         mocked_session.offset.return_value = mocked_session
+
+        # Mock context creation
+        mocked_session.__enter__.return_value = mocked_session
 
         mocked_session.all.side_effect = exc.OperationalError(
             statement='SQL QUERY', params=[], orig=1)


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-hive/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Improved the way the database session is created using a contextmanager, that way the session is automatically closed on each paginated query,  and  added a final `dispose` call to make sure all connections have been closed.
Also increased the connection poll size. 

**- How I did it**
Used  the `contextmanager` library and `session.close` and `dispose` logic.

**- How to verify it**
Run the connector in a hive metastore with 15000+ tables.

**- Description for the changelog**
This is a follow up optimization from the PR #23. Improves session clean up and connection pool handling.

