### PR TITLE
ADD formatting strategy to entry fields that have hard limits on Data Catalog

### DIFF
--- a/google-datacatalog-hive-connector/setup.py
+++ b/google-datacatalog-hive-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-hive-connector',
-    version='0.8.1',
+    version='0.9.0',
     author='Google LLC',
     description=
     'Library for ingesting Hive metadata into Google Cloud Data Catalog',

--- a/google-datacatalog-hive-connector/src/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-hive-connector/src/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory.py
@@ -41,7 +41,7 @@ class DataCatalogEntryFactory(BaseEntryFactory):
         entry.user_specified_type = 'database'
         entry.user_specified_system = 'hive'
 
-        entry.display_name = database_metadata.name
+        entry.display_name = self._format_display_name(database_metadata.name)
 
         entry.name = datacatalog.DataCatalogClient.entry_path(
             self.__project_id, self.__location_id, self.__entry_group_id,
@@ -67,7 +67,7 @@ class DataCatalogEntryFactory(BaseEntryFactory):
         entry.user_specified_type = 'table'
         entry.user_specified_system = 'hive'
 
-        entry.display_name = table_metadata.name
+        entry.display_name = self._format_display_name(table_metadata.name)
 
         entry.name = datacatalog.DataCatalogClient.entry_path(
             self.__project_id, self.__location_id, self.__entry_group_id,

--- a/google-datacatalog-hive-connector/src/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-hive-connector/src/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory.py
@@ -109,12 +109,12 @@ class DataCatalogEntryFactory(BaseEntryFactory):
         return entry_id, entry
 
     def __make_entry_id_for_table(self, database_name, table_metadata):
-        # We normalize and hash first the database_name
+        # We normalize and hash first the database_name.
         normalized_database_name = self._format_id_with_hashing(
             database_name.lower(),
             regex_pattern=self.__ENTRY_ID_INVALID_CHARS_REGEX_PATTERN)
 
-        # Next we do the same for the table name
+        # Next we do the same for the table name.
         normalized_table_name = self._format_id_with_hashing(
             table_metadata.name.lower(),
             regex_pattern=self.__ENTRY_ID_INVALID_CHARS_REGEX_PATTERN)

--- a/google-datacatalog-hive-connector/src/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-hive-connector/src/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory.py
@@ -17,11 +17,10 @@
 from google.cloud import datacatalog
 from google.protobuf import timestamp_pb2
 
-from google.datacatalog_connectors.commons.prepare.base_entry_factory import \
-    BaseEntryFactory
+from google.datacatalog_connectors.commons.prepare import base_entry_factory
 
 
-class DataCatalogEntryFactory(BaseEntryFactory):
+class DataCatalogEntryFactory(base_entry_factory.BaseEntryFactory):
     __ENTRY_ID_INVALID_CHARS_REGEX_PATTERN = r'[^a-zA-Z0-9_]+'
 
     def __init__(self, project_id, location_id, metadata_host_server,

--- a/google-datacatalog-hive-connector/src/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-hive-connector/src/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory.py
@@ -51,10 +51,10 @@ class DataCatalogEntryFactory(BaseEntryFactory):
         if isinstance(database_desc, str):
             entry.description = database_desc
         entry.linked_resource = \
-            '//{}//{}'.format(
+            self._format_linked_resource('//{}//{}'.format(
                 self.__metadata_host_server,
                 database_metadata.uri
-            )
+            ))
 
         return entry_id, entry
 
@@ -76,8 +76,9 @@ class DataCatalogEntryFactory(BaseEntryFactory):
         table_storage = table_metadata.table_storages[0]
 
         entry.linked_resource = \
-            '//{}//{}'.format(self.__metadata_host_server,
-                              table_storage.location)
+            self._format_linked_resource(
+                '//{}//{}'.format(self.__metadata_host_server,
+                                  table_storage.location))
 
         created_timestamp = timestamp_pb2.Timestamp()
         created_timestamp.FromSeconds(table_metadata.create_time)

--- a/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/assembled_entry_factory_test.py
@@ -37,13 +37,11 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
             self, entry_path):  # noqa
 
         entry_path.return_value = \
-            AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH
+            self.__MOCKED_ENTRY_PATH
 
         factory = assembled_entry_factory.AssembledEntryFactory(
-            AssembledEntryFactoryTestCase.__PROJECT_ID,
-            AssembledEntryFactoryTestCase.__LOCATION_ID,
-            AssembledEntryFactoryTestCase.__METADATA_SERVER_HOST,
-            AssembledEntryFactoryTestCase.__ENTRY_GROUP_ID)
+            self.__PROJECT_ID, self.__LOCATION_ID, self.__METADATA_SERVER_HOST,
+            self.__ENTRY_GROUP_ID)
 
         database_metadata = convert_json_to_metadata_object(
             retrieve_json_file('databases.json'))
@@ -73,16 +71,14 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
         self.__assert_created_entry_fields(assembled_entries)
 
     def test_database_metadata_invalid_ids_should_be_converted_to_assembled_entries(  # noqa:E501
-            self, entry_path):  # noqa
+            self, entry_path):
 
         entry_path.return_value = \
-            AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH
+            self.__MOCKED_ENTRY_PATH
 
         factory = assembled_entry_factory.AssembledEntryFactory(
-            AssembledEntryFactoryTestCase.__PROJECT_ID,
-            AssembledEntryFactoryTestCase.__LOCATION_ID,
-            AssembledEntryFactoryTestCase.__METADATA_SERVER_HOST,
-            AssembledEntryFactoryTestCase.__ENTRY_GROUP_ID)
+            self.__PROJECT_ID, self.__LOCATION_ID, self.__METADATA_SERVER_HOST,
+            self.__ENTRY_GROUP_ID)
 
         database_metadata = convert_json_to_metadata_object(
             retrieve_json_file('databases_invalid_ids.json'))
@@ -129,12 +125,10 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
     def test_database_metadata_should_be_converted_to_assembled_entries_verify_all_fields(  # noqa: E501
             self, entry_path):
         entry_path.return_value = \
-            AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH
+            self.__MOCKED_ENTRY_PATH
         factory = assembled_entry_factory.AssembledEntryFactory(
-            AssembledEntryFactoryTestCase.__PROJECT_ID,
-            AssembledEntryFactoryTestCase.__LOCATION_ID,
-            AssembledEntryFactoryTestCase.__METADATA_SERVER_HOST,
-            AssembledEntryFactoryTestCase.__ENTRY_GROUP_ID)
+            self.__PROJECT_ID, self.__LOCATION_ID, self.__METADATA_SERVER_HOST,
+            self.__ENTRY_GROUP_ID)
 
         database_metadata = convert_json_to_metadata_object(
             retrieve_json_file('databases_with_one_table.json'))
@@ -195,12 +189,10 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
     def test_database_metadata_no_tables_should_be_converted_to_datacatalog_entries(  # noqa: E501
             self, entry_path):
         entry_path.return_value = \
-            AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH
+            self.__MOCKED_ENTRY_PATH
         factory = assembled_entry_factory.AssembledEntryFactory(
-            AssembledEntryFactoryTestCase.__PROJECT_ID,
-            AssembledEntryFactoryTestCase.__LOCATION_ID,
-            AssembledEntryFactoryTestCase.__METADATA_SERVER_HOST,
-            AssembledEntryFactoryTestCase.__ENTRY_GROUP_ID)
+            self.__PROJECT_ID, self.__LOCATION_ID, self.__METADATA_SERVER_HOST,
+            self.__ENTRY_GROUP_ID)
 
         database_metadata = convert_json_to_metadata_object(
             retrieve_json_file('databases_no_tables.json'))

--- a/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/assembled_entry_factory_test.py
@@ -36,8 +36,7 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
     def test_database_metadata_should_be_converted_to_assembled_entries(
             self, entry_path):  # noqa
 
-        entry_path.return_value = \
-            self.__MOCKED_ENTRY_PATH
+        entry_path.return_value = self.__MOCKED_ENTRY_PATH
 
         factory = assembled_entry_factory.AssembledEntryFactory(
             self.__PROJECT_ID, self.__LOCATION_ID, self.__METADATA_SERVER_HOST,
@@ -73,8 +72,7 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
     def test_database_metadata_invalid_ids_should_be_converted_to_assembled_entries(  # noqa:E501
             self, entry_path):
 
-        entry_path.return_value = \
-            self.__MOCKED_ENTRY_PATH
+        entry_path.return_value = self.__MOCKED_ENTRY_PATH
 
         factory = assembled_entry_factory.AssembledEntryFactory(
             self.__PROJECT_ID, self.__LOCATION_ID, self.__METADATA_SERVER_HOST,
@@ -124,8 +122,7 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
 
     def test_database_metadata_should_be_converted_to_assembled_entries_verify_all_fields(  # noqa: E501
             self, entry_path):
-        entry_path.return_value = \
-            self.__MOCKED_ENTRY_PATH
+        entry_path.return_value = self.__MOCKED_ENTRY_PATH
         factory = assembled_entry_factory.AssembledEntryFactory(
             self.__PROJECT_ID, self.__LOCATION_ID, self.__METADATA_SERVER_HOST,
             self.__ENTRY_GROUP_ID)
@@ -142,8 +139,7 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
 
             self.assertEqual('default', assembled_database.entry_id)
             self.assertEqual('database', database_entry.user_specified_type)
-            self.assertEqual(AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH,
-                             database_entry.name)
+            self.assertEqual(self.__MOCKED_ENTRY_PATH, database_entry.name)
             self.assertEqual('Default Hive database',
                              database_entry.description)
             self.assertEqual(
@@ -165,9 +161,7 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
                 # Assert specific fields for table
                 self.assertEqual('table', table_entry.user_specified_type)
                 self.assertEqual('hive', table_entry.user_specified_system)
-                self.assertEqual(
-                    AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH,
-                    table_entry.name)
+                self.assertEqual(self.__MOCKED_ENTRY_PATH, table_entry.name)
                 self.assertEqual(
                     '//metadata_host//hdfs://'
                     'namenode:8020/user/hive/warehouse/funds',
@@ -188,8 +182,7 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
 
     def test_database_metadata_no_tables_should_be_converted_to_datacatalog_entries(  # noqa: E501
             self, entry_path):
-        entry_path.return_value = \
-            self.__MOCKED_ENTRY_PATH
+        entry_path.return_value = self.__MOCKED_ENTRY_PATH
         factory = assembled_entry_factory.AssembledEntryFactory(
             self.__PROJECT_ID, self.__LOCATION_ID, self.__METADATA_SERVER_HOST,
             self.__ENTRY_GROUP_ID)
@@ -231,9 +224,8 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
             # Assert specific fields for database
             self.assertEqual('database', database_entry.user_specified_type)
             self.assertEqual('hive', database_entry.user_specified_system)
-            self.assertEqual(AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH,
-                             database_entry.name)
-            self.assertIn(AssembledEntryFactoryTestCase.__METADATA_SERVER_HOST,
+            self.assertEqual(self.__MOCKED_ENTRY_PATH, database_entry.name)
+            self.assertIn(self.__METADATA_SERVER_HOST,
                           database_entry.linked_resource)
 
             for user_defined_table in assembled_tables:
@@ -247,12 +239,9 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
                 # Assert specific fields for table
                 self.assertEqual('table', table_entry.user_specified_type)
                 self.assertEqual('hive', table_entry.user_specified_system)
-                self.assertEqual(
-                    AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH,
-                    table_entry.name)
-                self.assertIn(
-                    AssembledEntryFactoryTestCase.__METADATA_SERVER_HOST,
-                    table_entry.linked_resource)
+                self.assertEqual(self.__MOCKED_ENTRY_PATH, table_entry.name)
+                self.assertIn(self.__METADATA_SERVER_HOST,
+                              table_entry.linked_resource)
                 self.assertGreater(len(table_entry.schema.columns), 0)
                 for column in table_entry.schema.columns:
                     self.assertIsNotNone(column.type)

--- a/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory_test.py
@@ -35,9 +35,7 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
             retrieve_json_file('databases_with_one_table.json'))['databases']
 
         factory = datacatalog_entry_factory.DataCatalogEntryFactory(
-            self.__PROJECT_ID,
-            self.__LOCATION_ID,
-            self.__METADATA_SERVER_HOST,
+            self.__PROJECT_ID, self.__LOCATION_ID, self.__METADATA_SERVER_HOST,
             self.__ENTRY_GROUP_ID)
 
         entry_id, entry = \
@@ -63,9 +61,7 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
         table = databases[0].tables[0]
 
         factory = datacatalog_entry_factory.DataCatalogEntryFactory(
-            self.__PROJECT_ID,
-            self.__LOCATION_ID,
-            self.__METADATA_SERVER_HOST,
+            self.__PROJECT_ID, self.__LOCATION_ID, self.__METADATA_SERVER_HOST,
             self.__ENTRY_GROUP_ID)
 
         entry_id, entry = \
@@ -96,9 +92,7 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
         table = databases[0].tables[0]
 
         factory = datacatalog_entry_factory.DataCatalogEntryFactory(
-            self.__PROJECT_ID,
-            self.__LOCATION_ID,
-            self.__METADATA_SERVER_HOST,
+            self.__PROJECT_ID, self.__LOCATION_ID, self.__METADATA_SERVER_HOST,
             self.__ENTRY_GROUP_ID)
 
         invalid_database_name = 'my::::????)()()____invalid_huge_' \
@@ -137,9 +131,7 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
         table = databases[0].tables[0]
 
         factory = datacatalog_entry_factory.DataCatalogEntryFactory(
-            self.__PROJECT_ID,
-            self.__LOCATION_ID,
-            self.__METADATA_SERVER_HOST,
+            self.__PROJECT_ID, self.__LOCATION_ID, self.__METADATA_SERVER_HOST,
             self.__ENTRY_GROUP_ID)
 
         invalid_table_name = 'my::::????)()()____invalid_huge_' \
@@ -200,9 +192,7 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
             'too_long_and_needs_to_be_truncated'
 
         factory = datacatalog_entry_factory.DataCatalogEntryFactory(
-            self.__PROJECT_ID,
-            self.__LOCATION_ID,
-            self.__METADATA_SERVER_HOST,
+            self.__PROJECT_ID, self.__LOCATION_ID, self.__METADATA_SERVER_HOST,
             self.__ENTRY_GROUP_ID)
 
         entry_id, entry = \

--- a/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory_test.py
@@ -35,10 +35,10 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
             retrieve_json_file('databases_with_one_table.json'))['databases']
 
         factory = datacatalog_entry_factory.DataCatalogEntryFactory(
-            DataCatalogEntryFactoryTestCase.__PROJECT_ID,
-            DataCatalogEntryFactoryTestCase.__LOCATION_ID,
-            DataCatalogEntryFactoryTestCase.__METADATA_SERVER_HOST,
-            DataCatalogEntryFactoryTestCase.__ENTRY_GROUP_ID)
+            self.__PROJECT_ID,
+            self.__LOCATION_ID,
+            self.__METADATA_SERVER_HOST,
+            self.__ENTRY_GROUP_ID)
 
         entry_id, entry = \
             factory.make_entries_for_database(databases[0])
@@ -63,10 +63,10 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
         table = databases[0].tables[0]
 
         factory = datacatalog_entry_factory.DataCatalogEntryFactory(
-            DataCatalogEntryFactoryTestCase.__PROJECT_ID,
-            DataCatalogEntryFactoryTestCase.__LOCATION_ID,
-            DataCatalogEntryFactoryTestCase.__METADATA_SERVER_HOST,
-            DataCatalogEntryFactoryTestCase.__ENTRY_GROUP_ID)
+            self.__PROJECT_ID,
+            self.__LOCATION_ID,
+            self.__METADATA_SERVER_HOST,
+            self.__ENTRY_GROUP_ID)
 
         entry_id, entry = \
             factory.make_entry_for_table(table, 'my_datawarehouse')
@@ -96,10 +96,10 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
         table = databases[0].tables[0]
 
         factory = datacatalog_entry_factory.DataCatalogEntryFactory(
-            DataCatalogEntryFactoryTestCase.__PROJECT_ID,
-            DataCatalogEntryFactoryTestCase.__LOCATION_ID,
-            DataCatalogEntryFactoryTestCase.__METADATA_SERVER_HOST,
-            DataCatalogEntryFactoryTestCase.__ENTRY_GROUP_ID)
+            self.__PROJECT_ID,
+            self.__LOCATION_ID,
+            self.__METADATA_SERVER_HOST,
+            self.__ENTRY_GROUP_ID)
 
         invalid_database_name = 'my::::????)()()____invalid_huge_' \
                                 'database_name_!!!!!!_@@@@@@_with' \
@@ -137,10 +137,10 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
         table = databases[0].tables[0]
 
         factory = datacatalog_entry_factory.DataCatalogEntryFactory(
-            DataCatalogEntryFactoryTestCase.__PROJECT_ID,
-            DataCatalogEntryFactoryTestCase.__LOCATION_ID,
-            DataCatalogEntryFactoryTestCase.__METADATA_SERVER_HOST,
-            DataCatalogEntryFactoryTestCase.__ENTRY_GROUP_ID)
+            self.__PROJECT_ID,
+            self.__LOCATION_ID,
+            self.__METADATA_SERVER_HOST,
+            self.__ENTRY_GROUP_ID)
 
         invalid_table_name = 'my::::????)()()____invalid_huge_' \
                              'table_name_!!!!!!_@@@@@@_with' \
@@ -200,10 +200,10 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
             'too_long_and_needs_to_be_truncated'
 
         factory = datacatalog_entry_factory.DataCatalogEntryFactory(
-            DataCatalogEntryFactoryTestCase.__PROJECT_ID,
-            DataCatalogEntryFactoryTestCase.__LOCATION_ID,
-            DataCatalogEntryFactoryTestCase.__METADATA_SERVER_HOST,
-            DataCatalogEntryFactoryTestCase.__ENTRY_GROUP_ID)
+            self.__PROJECT_ID,
+            self.__LOCATION_ID,
+            self.__METADATA_SERVER_HOST,
+            self.__ENTRY_GROUP_ID)
 
         entry_id, entry = \
             factory.make_entry_for_table(table, 'my_datawarehouse')

--- a/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory_test.py
@@ -1,0 +1,256 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import unittest
+
+from google.datacatalog_connectors.hive.prepare import \
+    datacatalog_entry_factory
+
+
+class DataCatalogEntryFactoryTestCase(unittest.TestCase):
+    __MODULE_PATH = '{}'.format(os.path.dirname(os.path.abspath(__file__)))
+
+    __PROJECT_ID = 'test_project'
+    __LOCATION_ID = 'location_id'
+    __METADATA_SERVER_HOST = 'metadata_host'
+    __ENTRY_GROUP_ID = 'sql_database'
+
+    def test_make_entry_for_database_should_set_all_available_fields(
+            self):  # noqa:E125
+        databases = convert_json_to_metadata_object(
+            retrieve_json_file('databases_with_one_table.json'))['databases']
+
+        factory = datacatalog_entry_factory.DataCatalogEntryFactory(
+            DataCatalogEntryFactoryTestCase.__PROJECT_ID,
+            DataCatalogEntryFactoryTestCase.__LOCATION_ID,
+            DataCatalogEntryFactoryTestCase.__METADATA_SERVER_HOST,
+            DataCatalogEntryFactoryTestCase.__ENTRY_GROUP_ID)
+
+        entry_id, entry = \
+            factory.make_entries_for_database(databases[0])
+
+        self.assertEqual('default', entry_id)
+        self.assertEqual('default', entry.display_name)
+        self.assertEqual(
+            'projects/test_project/locations/location_id/'
+            'entryGroups/sql_database/entries/default', entry.name)
+        self.assertEqual('hive', entry.user_specified_system)
+        self.assertEqual('database', entry.user_specified_type)
+        self.assertEqual(
+            '//metadata_host//hdfs://'
+            'namenode:8020/user/hive/warehouse', entry.linked_resource)
+        self.assertIsNone(entry.source_system_timestamps.create_time)
+        self.assertIsNone(entry.source_system_timestamps.update_time)
+
+    def test_make_entry_for_table_should_set_all_available_fields(
+            self):  # noqa:E125
+        databases = convert_json_to_metadata_object(
+            retrieve_json_file('databases_with_one_table.json'))['databases']
+
+        table = databases[0].tables[0]
+
+        factory = datacatalog_entry_factory.DataCatalogEntryFactory(
+            DataCatalogEntryFactoryTestCase.__PROJECT_ID,
+            DataCatalogEntryFactoryTestCase.__LOCATION_ID,
+            DataCatalogEntryFactoryTestCase.__METADATA_SERVER_HOST,
+            DataCatalogEntryFactoryTestCase.__ENTRY_GROUP_ID)
+
+        entry_id, entry = \
+            factory.make_entry_for_table(table, 'my_datawarehouse')
+
+        self.assertEqual('my_datawarehouse__funds', entry_id)
+        self.assertEqual('funds', entry.display_name)
+        self.assertEqual(
+            'projects/test_project/locations/location_id/'
+            'entryGroups/sql_database/entries/'
+            'my_datawarehouse__funds', entry.name)
+        self.assertEqual('hive', entry.user_specified_system)
+        self.assertEqual('table', entry.user_specified_type)
+        self.assertEqual(
+            '//metadata_host//'
+            'hdfs://namenode:8020/user/hive/warehouse/funds',
+            entry.linked_resource)
+        self.assertEqual('2019-09-03 13:57:28+00:00',
+                         str(entry.source_system_timestamps.create_time))
+        self.assertEqual('2019-09-03 13:57:58+00:00',
+                         str(entry.source_system_timestamps.update_time))
+
+    def test_make_entry_for_table_invalid_database_name_should_set_all_available_fields(  # noqa:E501
+            self):  # noqa:E125
+        databases = convert_json_to_metadata_object(
+            retrieve_json_file('databases_with_one_table.json'))['databases']
+
+        table = databases[0].tables[0]
+
+        factory = datacatalog_entry_factory.DataCatalogEntryFactory(
+            DataCatalogEntryFactoryTestCase.__PROJECT_ID,
+            DataCatalogEntryFactoryTestCase.__LOCATION_ID,
+            DataCatalogEntryFactoryTestCase.__METADATA_SERVER_HOST,
+            DataCatalogEntryFactoryTestCase.__ENTRY_GROUP_ID)
+
+        invalid_database_name = 'my::::????)()()____invalid_huge_' \
+                                'database_name_!!!!!!_@@@@@@_with' \
+                                '_chars_not_supported_by_dc_and_a' \
+                                'length_that_is_too_long_and_needs' \
+                                '_to_be_truncated'
+
+        entry_id, entry = \
+            factory.make_entry_for_table(table, invalid_database_name)
+
+        self.assertEqual(
+            'my_____invalid_huge_database_name'
+            '_____with_chars_not_supecec4307', entry_id)
+        self.assertEqual('funds', entry.display_name)
+        self.assertEqual(
+            'projects/test_project/locations/location_id/entryGroups/'
+            'sql_database/entries/my_____invalid_huge_database_name'
+            '_____with_chars_not_supecec4307', entry.name)
+        self.assertEqual('hive', entry.user_specified_system)
+        self.assertEqual('table', entry.user_specified_type)
+        self.assertEqual(
+            '//metadata_host//'
+            'hdfs://namenode:8020/user/hive/warehouse/funds',
+            entry.linked_resource)
+        self.assertEqual('2019-09-03 13:57:28+00:00',
+                         str(entry.source_system_timestamps.create_time))
+        self.assertEqual('2019-09-03 13:57:58+00:00',
+                         str(entry.source_system_timestamps.update_time))
+
+    def test_make_entry_for_table_invalid_table_name_should_set_all_available_fields(  # noqa:E501
+            self):  # noqa:E125
+        databases = convert_json_to_metadata_object(
+            retrieve_json_file('databases_with_one_table.json'))['databases']
+
+        table = databases[0].tables[0]
+
+        factory = datacatalog_entry_factory.DataCatalogEntryFactory(
+            DataCatalogEntryFactoryTestCase.__PROJECT_ID,
+            DataCatalogEntryFactoryTestCase.__LOCATION_ID,
+            DataCatalogEntryFactoryTestCase.__METADATA_SERVER_HOST,
+            DataCatalogEntryFactoryTestCase.__ENTRY_GROUP_ID)
+
+        invalid_table_name = 'my::::????)()()____invalid_huge_' \
+                             'table_name_!!!!!!_@@@@@@_with' \
+                             '_chars_not_supported_by_dc_and_a' \
+                             'length_that_is_too_long_and_needs' \
+                             '_to_be_truncated'
+
+        table.name = invalid_table_name
+
+        entry_id, entry = \
+            factory.make_entry_for_table(table, 'my_datawarehouse')
+
+        self.assertEqual(
+            'my_datawarehouse__my_____'
+            'invalid_huge_table_name_____wit0d3e0443', entry_id)
+        self.assertEqual(
+            'my_____invalid_huge_table_name_____'
+            'with_chars_not_supported_by_dc_and_'
+            'alength_that_is_too_long_and_needs_'
+            'to_be_truncated', entry.display_name)
+        self.assertEqual(
+            'projects/test_project/locations/location_id/entryGroups/'
+            'sql_database/entries/my_datawarehouse__my_____'
+            'invalid_huge_table_name_____wit0d3e0443', entry.name)
+        self.assertEqual('hive', entry.user_specified_system)
+        self.assertEqual('table', entry.user_specified_type)
+        self.assertEqual(
+            '//metadata_host//'
+            'hdfs://namenode:8020/user/hive/warehouse/funds',
+            entry.linked_resource)
+        self.assertEqual('2019-09-03 13:57:28+00:00',
+                         str(entry.source_system_timestamps.create_time))
+        self.assertEqual('2019-09-03 13:57:58+00:00',
+                         str(entry.source_system_timestamps.update_time))
+
+    def test_make_entry_for_table_long_linked_resource_should_set_all_available_fields(  # noqa:E501
+            self):  # noqa:E125
+        databases = convert_json_to_metadata_object(
+            retrieve_json_file('databases_with_one_table.json'))['databases']
+
+        table = databases[0].tables[0]
+
+        table.table_storages[0].location = \
+            'my::::????)()()____invalid_huge_table_name_!!!!!!_@@@@@@_with' \
+            '_chars_not_supported_by_dc_and_alength_that_is_' \
+            'too_long_and_needs_to_be_truncated' \
+            'too_long_and_needs_to_be_truncated' \
+            'too_long_and_needs_to_be_truncated' \
+            'too_long_and_needs_to_be_truncated' \
+            'too_long_and_needs_to_be_truncated' \
+            'too_long_and_needs_to_be_truncated' \
+            'too_long_and_needs_to_be_truncated' \
+            'too_long_and_needs_to_be_truncated' \
+            'too_long_and_needs_to_be_truncated' \
+            'too_long_and_needs_to_be_truncated' \
+            'too_long_and_needs_to_be_truncated' \
+            'too_long_and_needs_to_be_truncated'
+
+        factory = datacatalog_entry_factory.DataCatalogEntryFactory(
+            DataCatalogEntryFactoryTestCase.__PROJECT_ID,
+            DataCatalogEntryFactoryTestCase.__LOCATION_ID,
+            DataCatalogEntryFactoryTestCase.__METADATA_SERVER_HOST,
+            DataCatalogEntryFactoryTestCase.__ENTRY_GROUP_ID)
+
+        entry_id, entry = \
+            factory.make_entry_for_table(table, 'my_datawarehouse')
+
+        self.assertEqual('my_datawarehouse__funds', entry_id)
+        self.assertEqual('funds', entry.display_name)
+        self.assertEqual(
+            'projects/test_project/locations/location_id/'
+            'entryGroups/sql_database/entries/'
+            'my_datawarehouse__funds', entry.name)
+        self.assertEqual('hive', entry.user_specified_system)
+        self.assertEqual('table', entry.user_specified_type)
+        self.assertEqual(
+            '//metadata_host//my::::_____invalid_huge_table_name'
+            '_____with_chars_not_supported_by_dc_and_alength_that'
+            '_is_too_long_and_needs_to_be_truncatedtoo_long_and_'
+            'needs_to_be_truncatedtoo_long_and_needs_to_...',
+            entry.linked_resource)
+        self.assertEqual('2019-09-03 13:57:28+00:00',
+                         str(entry.source_system_timestamps.create_time))
+        self.assertEqual('2019-09-03 13:57:58+00:00',
+                         str(entry.source_system_timestamps.update_time))
+
+
+def retrieve_json_file(name):
+    resolved_name = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                 '../test_data/{}'.format(name))
+
+    with open(resolved_name) as json_file:
+        return json_file.read()
+
+
+def convert_json_to_metadata_object(parsed_json):
+    return {
+        'databases':
+            json.loads(
+                parsed_json,
+                object_hook=lambda dict_obj: DictWithAttributeAccess(dict_obj))
+    }
+
+
+class DictWithAttributeAccess(dict):
+
+    def __getattr__(self, key):
+        return self[key]
+
+    def __setattr__(self, key, value):
+        self[key] = value

--- a/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/prepare/datacatalog_entry_factory_test.py
@@ -30,8 +30,7 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
     __METADATA_SERVER_HOST = 'metadata_host'
     __ENTRY_GROUP_ID = 'sql_database'
 
-    def test_make_entry_for_database_should_set_all_available_fields(
-            self):  # noqa:E125
+    def test_make_entry_for_database_should_set_all_available_fields(self):
         databases = convert_json_to_metadata_object(
             retrieve_json_file('databases_with_one_table.json'))['databases']
 
@@ -57,8 +56,7 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
         self.assertIsNone(entry.source_system_timestamps.create_time)
         self.assertIsNone(entry.source_system_timestamps.update_time)
 
-    def test_make_entry_for_table_should_set_all_available_fields(
-            self):  # noqa:E125
+    def test_make_entry_for_table_should_set_all_available_fields(self):
         databases = convert_json_to_metadata_object(
             retrieve_json_file('databases_with_one_table.json'))['databases']
 
@@ -91,7 +89,7 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
                          str(entry.source_system_timestamps.update_time))
 
     def test_make_entry_for_table_invalid_database_name_should_set_all_available_fields(  # noqa:E501
-            self):  # noqa:E125
+            self):
         databases = convert_json_to_metadata_object(
             retrieve_json_file('databases_with_one_table.json'))['databases']
 
@@ -132,7 +130,7 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
                          str(entry.source_system_timestamps.update_time))
 
     def test_make_entry_for_table_invalid_table_name_should_set_all_available_fields(  # noqa:E501
-            self):  # noqa:E125
+            self):
         databases = convert_json_to_metadata_object(
             retrieve_json_file('databases_with_one_table.json'))['databases']
 
@@ -179,7 +177,7 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
                          str(entry.source_system_timestamps.update_time))
 
     def test_make_entry_for_table_long_linked_resource_should_set_all_available_fields(  # noqa:E501
-            self):  # noqa:E125
+            self):
         databases = convert_json_to_metadata_object(
             retrieve_json_file('databases_with_one_table.json'))['databases']
 
@@ -187,7 +185,7 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
 
         table.table_storages[0].location = \
             'my::::????)()()____invalid_huge_table_name_!!!!!!_@@@@@@_with' \
-            '_chars_not_supported_by_dc_and_alength_that_is_' \
+            '_chars_not_supported_by_dc_and_a_length_that_is_' \
             'too_long_and_needs_to_be_truncated' \
             'too_long_and_needs_to_be_truncated' \
             'too_long_and_needs_to_be_truncated' \
@@ -220,9 +218,9 @@ class DataCatalogEntryFactoryTestCase(unittest.TestCase):
         self.assertEqual('table', entry.user_specified_type)
         self.assertEqual(
             '//metadata_host//my::::_____invalid_huge_table_name'
-            '_____with_chars_not_supported_by_dc_and_alength_that'
-            '_is_too_long_and_needs_to_be_truncatedtoo_long_and_'
-            'needs_to_be_truncatedtoo_long_and_needs_to_...',
+            '_____with_chars_not_supported_by_dc_and_a_length_that'
+            '_is_too_long_and_needs_to_be_truncatedtoo_long_and'
+            '_needs_to_be_truncatedtoo_long_and_needs_to...',
             entry.linked_resource)
         self.assertEqual('2019-09-03 13:57:28+00:00',
                          str(entry.source_system_timestamps.create_time))

--- a/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/test_data/databases_invalid_ids.json
+++ b/google-datacatalog-hive-connector/tests/google/datacatalog_connectors/hive/test_data/databases_invalid_ids.json
@@ -1,0 +1,82 @@
+[
+    {
+        "id": 1,
+        "name": "organization_warehouse7192ecb2",
+        "desc": "Default Hive database",
+        "uri": "hdfs://namenode:8020/user/hive/warehouse",
+        "tables": [
+            {
+                "id": 1,
+                "name": "personsc3a8d512_business_area_and_segment_of_marketing",
+                "type": "MANAGED_TABLE",
+                "create_time": 1567519048,
+                "database_id": 1,
+                "sd_id": 1,
+                "table_storages": [
+                    {
+                        "sd_id": 1,
+                        "location": "hdfs://namenode:8020/user/hive/warehouse/funds",
+                        "cd_id": 2,
+                        "columns": [
+                            {
+                                "id": 2,
+                                "name": "addr",
+                                "type": "string",
+                                "comment": "a new addr column"
+                            },
+                            {
+                                "id": 2,
+                                "name": "bar",
+                                "type": "string",
+                                "comment": null
+                            },
+                            {
+                                "id": 2,
+                                "name": "foo",
+                                "type": "int",
+                                "comment": null
+                            }
+                        ]
+                    }
+                ],
+                "table_params": [
+                    {
+                        "id": 1,
+                        "param_key": "last_modified_by",
+                        "param_value": "root"
+                    },
+                    {
+                        "id": 1,
+                        "param_key": "last_modified_time",
+                        "param_value": "1567519078"
+                    },
+                    {
+                        "id": 1,
+                        "param_key": "transient_lastDdlTime",
+                        "param_value": "1567519078"
+                    },
+                    {
+                        "id": 1,
+                        "param_key": "numFiles",
+                        "param_value": "1"
+                    },
+                    {
+                        "id": 1,
+                        "param_key": "rawDataSize",
+                        "param_value": "0"
+                    },
+                    {
+                        "id": 1,
+                        "param_key": "numRows",
+                        "param_value": "0"
+                    },
+                    {
+                        "id": 1,
+                        "param_key": "totalSize",
+                        "param_value": "5812"
+                    }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-hive/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**

- Added `_format_id_with_hashing` logic to entry ID.
- Added `_format_display_name` logic to entry Display Name.
- Added `_format_linked_resource` logic to Linked Resource. 

**- How I did it**

Used the methods implemented in the commons library to make those fields compliant with Data Catalog hard limits.

**- How to verify it**
Run the hive connector on a hive server containing tables with long table names 200+, it should run successfully.

**- Description for the changelog**
Added formatting strategy to entry fields that have hard limits on Data Catalog.
Fixes #25.
