### PR TITLE
chore: upgrade log4j version to 2.17.1

### DIFF
--- a/hive-metastore-listener/pom.xml
+++ b/hive-metastore-listener/pom.xml
@@ -71,12 +71,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hive</groupId>


### PR DESCRIPTION
- **What I did**

Upgraded log4j library to mitigate vulnerability found in an earlier version: [logging.apache.org/log4j/2.x/security.html](https://logging.apache.org/log4j/2.x/security.html).

- **How I did it**

Changed version to `2.17.1` in `pom.xml`.